### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "collaboration"
   ],
   "description": "Only instance admin has permissions to run it",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "main_script": "src/create_users_from_csv.py",
   "task_location": "application_sessions",
   "icon": "https://img.icons8.com/color/96/000000/group.png",

--- a/config.json
+++ b/config.json
@@ -1,21 +1,21 @@
 {
-    "name": "Create users from CSV",
-    "type": "app",
-    "instance_version": "6.15.60",
-    "categories": [
-        "collaboration"
-    ],
-    "description": "Only instance admin has permissions to run it",
-    "docker_image": "supervisely/collaboration:6.73.564",
-    "main_script": "src/create_users_from_csv.py",
-    "task_location": "application_sessions",
-    "icon": "https://img.icons8.com/color/96/000000/group.png",
-    "icon_background": "#FFFFFF",
-    "headless": true,
-    "context_menu": {
-        "target": [
-            "files_file"
-        ]
-    },
-    "poster": "https://user-images.githubusercontent.com/48245050/182578612-7a10814b-7494-4ae3-aa62-486171fcc480.png"
+  "name": "Create users from CSV",
+  "type": "app",
+  "instance_version": "6.15.60",
+  "categories": [
+    "collaboration"
+  ],
+  "description": "Only instance admin has permissions to run it",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "main_script": "src/create_users_from_csv.py",
+  "task_location": "application_sessions",
+  "icon": "https://img.icons8.com/color/96/000000/group.png",
+  "icon_background": "#FFFFFF",
+  "headless": true,
+  "context_menu": {
+    "target": [
+      "files_file"
+    ]
+  },
+  "poster": "https://user-images.githubusercontent.com/48245050/182578612-7a10814b-7494-4ae3-aa62-486171fcc480.png"
 }

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
         "collaboration"
     ],
     "description": "Only instance admin has permissions to run it",
-    "docker_image": "supervisely/collaboration:0.0.5",
+    "docker_image": "supervisely/collaboration:6.73.564",
     "main_script": "src/create_users_from_csv.py",
     "task_location": "application_sessions",
     "icon": "https://img.icons8.com/color/96/000000/group.png",

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "name": "Create users from CSV",
     "type": "app",
+    "instance_version": "6.15.60",
     "categories": [
         "collaboration"
     ],

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.70
+supervisely==6.73.564

--- a/src/create_users_from_csv.py
+++ b/src/create_users_from_csv.py
@@ -2,7 +2,7 @@ import os
 import csv
 import io
 
-import supervisely_lib as sly
+import supervisely as sly
 
 my_app = sly.AppService()
 


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
